### PR TITLE
ya-errata-import.pl: Add API version 16

### DIFF
--- a/ya-errata-import.pl
+++ b/ya-errata-import.pl
@@ -49,7 +49,7 @@ use Time::Local;
 
 # Version information
 my $version = "20150303";
-my @supportedapi = ( '10.9','10.11','11.00','11.1','12','13','14','15' );
+my @supportedapi = ( '10.9','10.11','11.00','11.1','12','13','14','15','16' );
 
 # Just to be sure: disable SSL certificate verification for libwww>6.0
 $ENV{'PERL_LWP_SSL_VERIFY_HOSTNAME'} = 0;


### PR DESCRIPTION
Need this to prevent the following:

ERROR: Your API version (16) is not supported. Try upgrading this script.

Tested the new API and everything seems to work fine with this change.

Signed-off-by: Sol Jerome <sol@resolvity.com>