### PR TITLE
lists.centos.org will return a redirect when using HTTP

### DIFF
--- a/centos-clone-errata-full.sh
+++ b/centos-clone-errata-full.sh
@@ -38,7 +38,7 @@ fullChargeErrata()
 {
   # Retrieve all years from emails sent to list, since 2004. This function will sign all erratas from digest
   # available in the mail list.
-  yearmon=$(curl http://lists.centos.org/pipermail/centos/index.html|grep date.html|cut -d"\"" -f2|cut -d"/" -f1)
+  yearmon=$(curl https://lists.centos.org/pipermail/centos/index.html|grep date.html|cut -d"\"" -f2|cut -d"/" -f1)
 
   # create and/or cleanup the errata dir
   ERRATADIR=/tmp/centos-errata
@@ -49,7 +49,7 @@ fullChargeErrata()
 
 
     # Use wget to fetch the errata data from centos.org
-    listurl=http://lists.centos.org/pipermail/centos
+    listurl=https://lists.centos.org/pipermail/centos
     { for d in $yearmon; do
 	  wget --no-cache -q -O- $listurl/$d/date.html \
 		| sed -n 's|.*"\([^"]*\)".*CentOS-announce Digest.*|'"$d/\\1|p"		| tee -a $LogFile

--- a/centos-clone-errata.sh
+++ b/centos-clone-errata.sh
@@ -56,7 +56,7 @@ ERRATADIR=/tmp/centos-errata
    fi
 
    # Use wget to fetch the errata data from centos.org
-   listurl=http://lists.centos.org/pipermail/centos
+   listurl=https://lists.centos.org/pipermail/centos
    { for d in $yearmon; do
 	  wget --no-cache -q -O- $listurl/$d/date.html \
 		| sed -n 's|.*"\([^"]*\)".*CentOS-announce Digest.*|'"$d/\\1|p"
@@ -64,7 +64,7 @@ ERRATADIR=/tmp/centos-errata
    } |	tail -n $NBR_DIGESTS | xargs -n1 -I{} wget -q $listurl/{}
 
    # the ye old simple way, left as an example for reference:
-   #wget --no-cache -q -O- http://lists.centos.org/pipermail/centos/$DATE/date.html| grep "CentOS-announce Digest" |tail -n 5 |cut -d"\"" -f2|xargs -n1 -I{} wget -q http://lists.centos.org/pipermail/centos/$DATE/{}
+   #wget --no-cache -q -O- https://lists.centos.org/pipermail/centos/$DATE/date.html| grep "CentOS-announce Digest" |tail -n 5 |cut -d"\"" -f2|xargs -n1 -I{} wget -q http://lists.centos.org/pipermail/centos/$DATE/{}
 )
 
 #### EDIT SECTION 2 HERE ####


### PR DESCRIPTION
curl will not redirect to https.  Once changed, lists.centos.org works again.